### PR TITLE
Update aligned_reads.yaml

### DIFF
--- a/gdcdictionary/schemas/aligned_reads.yaml
+++ b/gdcdictionary/schemas/aligned_reads.yaml
@@ -47,7 +47,6 @@ required:
   - data_type
   - data_format
   - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [ id ]


### PR DESCRIPTION
Removed the requirement of 'platform' as this is not required in the parent node "read_group".